### PR TITLE
fix(nextcloud): accept relative user_path in _resolve_path (#19)

### DIFF
--- a/daemon/src/cloud_drive_sync/providers/nextcloud/client.py
+++ b/daemon/src/cloud_drive_sync/providers/nextcloud/client.py
@@ -72,18 +72,35 @@ class NextcloudClient(CloudClient):
     def _resolve_path(self, file_id: str) -> str:
         """Return the WebDAV path for a file_id.
 
-        New IDs are WebDAV paths (start with /). Legacy IDs from older sync
-        databases are compound Nextcloud fileids like ``00000162ocmvvvbtlon4``
-        — extract the numeric prefix and call by_id as a fallback.
+        File IDs fall into three shapes:
+
+        * ``"root"`` / ``"/"`` → the user root.
+        * Absolute WebDAV path (``"/Documents"``) → normalised and returned.
+        * Relative ``FsNode.user_path`` as returned by nc-py-api
+          (``"Documents"``, ``"Documents/ManuAndI"``). nc-py-api strips the
+          leading slash; treat these as relative paths and prepend ``/``.
+        * Legacy Nextcloud compound fileid
+          (``"00000162ocmvvvbtlon4"`` — ≥ 8 zero-padded hex digits + a random
+          suffix) left over from pre-path sync databases. Look up via
+          ``by_id`` as a fallback.
+
+        Previously anything not starting with ``/`` ran straight into the
+        legacy lookup, so a perfectly valid ``user_path`` like ``"Documents"``
+        (no digits to strip) raised ``ValueError``; callers that swallowed
+        the exception then silently refused to find existing child folders,
+        causing ``MKCOL`` races on nested-directory creation (#19).
         """
         if file_id == "root" or file_id == "/":
             return "/"
         if file_id.startswith("/"):
             return self._normalise_path(file_id)
-        # Legacy compound fileid: strip non-digit suffix and look up by integer ID
+        # Path-like values (slash, dot, or too short to be a real fileid)
+        # must be treated as a relative WebDAV user_path.
         numeric = "".join(c for c in file_id if c.isdigit())
-        if not numeric:
-            raise ValueError(f"Cannot resolve Nextcloud file_id: {file_id!r}")
+        looks_like_fileid = len(numeric) >= 8 and len(file_id) >= 10
+        if "/" in file_id or "." in file_id or not looks_like_fileid:
+            return self._normalise_path("/" + file_id)
+        # Legacy compound fileid: strip non-digit suffix and look up by integer ID
         node = self._nc.files.by_id(int(numeric))
         if node is None:
             raise FileNotFoundError(f"Nextcloud file not found: fileid={file_id}")

--- a/daemon/tests/test_nextcloud_resolve_path.py
+++ b/daemon/tests/test_nextcloud_resolve_path.py
@@ -1,0 +1,50 @@
+"""Regression tests for issue #19 — NextcloudClient._resolve_path
+must accept the relative user_path values returned by nc-py-api's
+FsNode (e.g. "Documents", "Documents/ManuAndI") and treat them as
+WebDAV paths rather than falling into the legacy-fileid branch and
+raising silently.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from cloud_drive_sync.providers.nextcloud.client import NextcloudClient
+
+
+@pytest.fixture
+def client():
+    # _resolve_path / _normalise_path don't touch _nc so a plain stub is fine.
+    c = NextcloudClient.__new__(NextcloudClient)
+    c._nc = MagicMock()
+    return c
+
+
+@pytest.mark.parametrize(
+    "file_id,expected",
+    [
+        ("root", "/"),
+        ("/", "/"),
+        ("/Documents", "/Documents"),
+        ("/Documents/", "/Documents"),
+        # Relative user_path forms returned by nc-py-api FsNode.user_path.
+        ("Documents", "/Documents"),
+        ("Documents/ManuAndI", "/Documents/ManuAndI"),
+        ("Documents/ManuAndI/Documents/AI Bills Folder",
+         "/Documents/ManuAndI/Documents/AI Bills Folder"),
+        # Path with a dot — should still be treated as a path, not a fileid.
+        ("report.pdf", "/report.pdf"),
+    ],
+)
+def test_resolve_path_returns_webdav_path(client, file_id, expected):
+    assert client._resolve_path(file_id) == expected
+
+
+def test_resolve_path_legacy_fileid_falls_back_to_by_id(client):
+    # Legacy compound fileid: 8+ hex-style digits followed by a random suffix.
+    legacy = "00000162ocmvvvbtlon4"
+    fake_node = MagicMock()
+    fake_node.user_path = "Documents"
+    client._nc.files.by_id.return_value = fake_node
+
+    assert client._resolve_path(legacy) == "Documents"
+    client._nc.files.by_id.assert_called_once_with(162)


### PR DESCRIPTION
## Summary

nc-py-api's \`FsNode.user_path\` strips the leading slash (e.g. \`'Documents'\`, \`'Documents/ManuAndI'\`). \`NextcloudClient._resolve_path\` only handled values that already started with \`/\`, so any relative \`user_path\` hit the legacy-compound-fileid branch — stripping non-digit chars from \`'Documents'\` left an empty string and raised \`ValueError\`.

\`find_child_folder\` swallows exceptions and returned \`None\`, so every deep lookup in \`_ensure_remote_dirs\` reported *"folder does not exist"* and re-issued a \`MKCOL\` against the full nested path before the intermediate folders had been created. Nextcloud responded \`405 Method Not Allowed\` on any sufficiently deep directory path — matching the failure log in #19.

## Fix

- Widen \`_resolve_path\`: values containing \`/\` or \`.\` are relative WebDAV paths; prepend \`/\` and normalise. Anything too short to be a real compound fileid (heuristic: fewer than 8 digits or under 10 chars total) also routes to the path branch.
- Keep the \`by_id()\` legacy fallback for genuine compound fileids (the \`00000162ocmvvvbtlon4\` shape that pre-path sync databases still hand back).

## Test plan

- [x] Added \`daemon/tests/test_nextcloud_resolve_path.py\` — a table-test against every path shape we were failing on (\`'Documents'\`, \`'Documents/ManuAndI'\`, the 4-level-deep \`'Documents/ManuAndI/Documents/AI Bills Folder'\` from the issue's repro log), plus the absolute-path form, and a parametric check that a legacy compound fileid still calls \`_nc.files.by_id(162)\`.
- [ ] Local pytest run was blocked by unrelated \`googleapiclient\` / \`platformdirs\` import pulls via the package \`__init__\`s; CI has the full dep tree installed.

Fixes #19